### PR TITLE
Fixed a small nested selector issue

### DIFF
--- a/.obsidian/snippets/dashboard.css
+++ b/.obsidian/snippets/dashboard.css
@@ -28,7 +28,7 @@
 
 
 /* Get rid of the parent bullet */
-.dashboard div.markdown-preview-section > div > ul > li > div.list-bullet {
+.dashboard div.markdown-preview-section > div > ul > li > .list-bullet {
     display: none !important;
 }
 


### PR DESCRIPTION
The bullet point in the title was being displayed. It seemed to have been an extra "div" in the selector heirarchy.